### PR TITLE
Fix prototype pollution in form keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ expect(object).toEqual({
   }
 })
 ```
+
+## Security
+
+Form keys containing `__proto__`, `constructor`, or `prototype` as an exact path segment are rejected to prevent prototype pollution. For example, `__proto__[polluted]` and `constructor[prototype][polluted]` throw an error instead of walking into inherited object prototypes.

--- a/index.cjs
+++ b/index.cjs
@@ -1,3 +1,15 @@
+const unsafeKeySegments = new Set(["__proto__", "constructor", "prototype"])
+
+function assertSafeKeySegment(key) {
+  if (unsafeKeySegments.has(key)) {
+    throw new Error(`Unsafe form key segment: ${key}`)
+  }
+}
+
+function hasOwn(object, key) {
+  return Object.prototype.hasOwnProperty.call(object, key)
+}
+
 module.exports = class FormDataToObject {
   static toObject(formData) {
     const formDataToObject = new FormDataToObject(formData)
@@ -40,9 +52,11 @@ module.exports = class FormDataToObject {
       const inputName = firstMatch[1]
       const rest = firstMatch[2]
 
+      assertSafeKeySegment(inputName)
+
       let newResult
 
-      if (inputName in result) {
+      if (hasOwn(result, inputName)) {
         newResult = result[inputName]
       } else if (rest == "[]") {
         newResult = []
@@ -54,6 +68,8 @@ module.exports = class FormDataToObject {
 
       this.treatSecond(value, rest, newResult)
     } else {
+      assertSafeKeySegment(key)
+
       result[key] = value
     }
   }
@@ -68,9 +84,13 @@ module.exports = class FormDataToObject {
     if (rest == "[]") {
       result.push(value)
     } else if (newRest == "") {
+      assertSafeKeySegment(key)
+
       result[key] = value
     } else {
-      if (typeof result == "object" && key in result) {
+      assertSafeKeySegment(key)
+
+      if (typeof result == "object" && hasOwn(result, key)) {
         newResult = result[key]
       } else if (newRest == "[]") {
         newResult = []

--- a/spec/form-data-objectizer-spec.cjs
+++ b/spec/form-data-objectizer-spec.cjs
@@ -1,7 +1,25 @@
 const FormData = require("./support/fake-form-data.cjs")
 const FormDataObjectizer = require("../index.cjs")
 
+function formDataWithEntries(entries) {
+  return {
+    entries() {
+      return entries
+    }
+  }
+}
+
+function expectUnsafeFormKey(formKey, unsafeKeySegment) {
+  const formData = formDataWithEntries([[formKey, "yes"]])
+
+  expect(() => FormDataObjectizer.toObject(formData)).toThrowError(Error, `Unsafe form key segment: ${unsafeKeySegment}`)
+}
+
 describe("form-data-objectizer", () => {
+  afterEach(() => {
+    delete Object.prototype.polluted
+  })
+
   it("converts nested keys", () => {
     const formData = new FormData()
 
@@ -22,6 +40,40 @@ describe("form-data-objectizer", () => {
             }
           }
         }
+      }
+    })
+  })
+
+  it("rejects __proto__ bracket keys without polluting Object.prototype", () => {
+    expectUnsafeFormKey("__proto__[polluted]", "__proto__")
+    expect({}.polluted).toBeUndefined()
+  })
+
+  it("rejects constructor prototype bracket keys without polluting Object.prototype", () => {
+    expectUnsafeFormKey("constructor[prototype][polluted]", "constructor")
+    expect({}.polluted).toBeUndefined()
+  })
+
+  it("rejects unsafe direct keys", () => {
+    for (const key of ["__proto__", "constructor", "prototype"]) {
+      expectUnsafeFormKey(key, key)
+    }
+  })
+
+  it("rejects unsafe nested keys", () => {
+    for (const key of ["__proto__", "constructor", "prototype"]) {
+      expectUnsafeFormKey(`user[${key}][polluted]`, key)
+    }
+  })
+
+  it("parses inherited non-reserved names as own properties", () => {
+    const formData = formDataWithEntries([["toString[value]", "yes"]])
+
+    const object = FormDataObjectizer.toObject(formData)
+
+    expect(object).toEqual({
+      toString: {
+        value: "yes"
       }
     })
   })


### PR DESCRIPTION
## Summary
- Reject `__proto__`, `constructor`, and `prototype` as exact form key segments.
- Replace prototype-chain `in` checks with own-property checks while walking parsed keys.
- Add security regression specs and document the rejected-key behavior.

## Tests
- `npm test -- spec/form-data-objectizer-spec.cjs`
- `git diff --check`